### PR TITLE
Check external links in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,3 +14,4 @@ jobs:
         uses: shalzz/zola-deploy-action@e37232516a63e8711048bda4e1afb9e0891f46fa
         env:
           BUILD_ONLY: true
+          CHECK_LINKS: true


### PR DESCRIPTION
Run `zola check` before building the page in GitHub Actions to check if external links are working properly.
