### PR TITLE
Fix path to fonts

### DIFF
--- a/sass/style.sass
+++ b/sass/style.sass
@@ -18,8 +18,6 @@ $white: #f3f3f3
   --bs-body-color: var(--bs-gray-700)
   --blue: #20567a
 
-// Extra fonts
-@import url("/fonts/Montserrat/fonts/webfonts/Montserrat.css")
 
 // :root:not([data-bs-theme=light])
 //   --bs-body-color: red

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="{{ get_url(path="bootstrap/css/bootstrap.min.css") }}" media="all" />
   <link rel="stylesheet" href="{{ get_url(path="fontawesome/css/all.min.css") }}" media="all" />
   <link rel="stylesheet" href="{{ get_url(path="style.css") }}" media="all" />
+  <link rel="stylesheet" type="text/css" href="{{ get_url(path="fonts/Montserrat/Montserrat.css") }}">
   <title></title>
 </head>
 


### PR DESCRIPTION
Move the import of the Montserrat fonts from the `style.sass` to the
`base.html`. This allows to use the base url set in Zola configuration.
