### PR TITLE
Extend deadline for abstract submission

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -31,3 +31,13 @@ where = [
     "University of British Columbia",
     "2207 Main Mall, Vancouver, BC",
 ]
+
+# Informational bar on top of pages
+#   * choose boostrap colors (primary, secondary, success, danger, warning, etc
+#   * for not having informational bars, just comment out the following lines
+[extra.infobar]
+text="""
+<i class="fa-solid fa-circle-info"></i>
+Deadline for [abstract submission](/#abstracts-call) got extended to **October 20**!
+"""
+color="warning"

--- a/config.toml
+++ b/config.toml
@@ -38,6 +38,6 @@ where = [
 [extra.infobar]
 text="""
 <i class="fa-solid fa-circle-info"></i>
-Deadline for [abstract submission](/#abstracts-call) got extended to **October 20**!
+The deadline for [abstract submission](/#abstracts-call) is extended to **October 20**!
 """
 color="warning"

--- a/sass/style.sass
+++ b/sass/style.sass
@@ -181,5 +181,8 @@ p + h2, p + h3, p + h4, p + h5
   padding-bottom: 8rem !important
   color: var(--bs-light-text-emphasis)
 
-.strike-out
-  text-decoration: line-through
+.infobar
+  margin: 0
+  text-align: center
+  padding-top: 0.7em
+  padding-bottom: 0.7em

--- a/sass/style.sass
+++ b/sass/style.sass
@@ -180,3 +180,6 @@ p + h2, p + h3, p + h4, p + h5
   padding-top: 8rem !important
   padding-bottom: 8rem !important
   color: var(--bs-light-text-emphasis)
+
+.strike-out
+  text-decoration: line-through

--- a/templates/base.html
+++ b/templates/base.html
@@ -21,6 +21,16 @@
 
 <body>
 
+  {% if config.extra.infobar %}
+    {% set alert_class = "" %}
+    {% if config.extra.infobar.color %}
+      {% set alert_class = "alert-" ~ config.extra.infobar.color %}
+    {% endif %}
+    <div class="infobar alert {{ alert_class }}" role="alert">
+      {{ config.extra.infobar.text | markdown(inline=true) | safe }}
+    </div>
+  {% endif %}
+
   {% block content %} {% endblock %}
 
 <script src="{{ get_url(path="bootstrap/js/bootstrap.bundle.min.js") }}"></script>

--- a/templates/home.html
+++ b/templates/home.html
@@ -84,13 +84,9 @@
               <i class="fa-solid fa-envelope-open-text"></i>
               Call for abstracts is open!
             </h3>
-            <div class="alert alert-info">
-              <i class="fa-solid fa-circle-info"></i>
-              Abstract deadline got extended!
-            </div>
             <div class="alert alert-warning">
               <i class="fa-solid fa-triangle-exclamation"></i>
-              Abstracts are due <span class="strike-out">October 13, 2023</span>
+              Abstracts are due <s>October 13, 2023</s>
               <br>
               <strong>October 20, 2023</strong>
             </div>

--- a/templates/home.html
+++ b/templates/home.html
@@ -78,15 +78,21 @@
     <section id="abstracts-call">
       <div class="container">
         <h2>Call for Abstracts</h2>
-        <div class="row me-auto ms-auto justify-content-evenly gy-4">
+        <div class="row me-auto ms-auto justify-content-evenly gy-5 align-items-center">
           <div class="col-xxl-4 col-xl-5 col-lg-6 col-sm-12 text-center">
             <h3>
               <i class="fa-solid fa-envelope-open-text"></i>
               Call for abstracts is open!
             </h3>
+            <div class="alert alert-info">
+              <i class="fa-solid fa-circle-info"></i>
+              Abstract deadline got extended!
+            </div>
             <div class="alert alert-warning">
               <i class="fa-solid fa-triangle-exclamation"></i>
-              Abstracts are due <strong>October 13, 2023</strong>
+              Abstracts are due <span class="strike-out">October 13, 2023</span>
+              <br>
+              <strong>October 20, 2023</strong>
             </div>
             <div class="d-flex flex-row align-items-center justify-content-center flex-wrap gap-2">
               <div class="dropdown">


### PR DESCRIPTION
Extend deadline to October 20, 2023. Strike out old date. Add new feature to
the `config.toml` file for easily including information bars on top of all
pages. Create a new information bar with the deadline extension news.
