### PR TITLE
Fix check of inconsistent times in program

### DIFF
--- a/templates/program.html
+++ b/templates/program.html
@@ -28,7 +28,7 @@
   <div class="row gy-5">
   {% for day, events in page.extra.events | group_by(attribute="day") %}
     {% set_global i = 0 %}
-    {% set_global previous_end = "" %}
+    {% set_global previous_end = 0 %}
 
     <div class="col-lg-6 col-md-12">
       <h2 id={{ day | date(format="%Y-%m-%d") }} class="timeline-day">{{ day | date(format="%A %e") }}</h2>
@@ -37,15 +37,17 @@
         <ul>
         {% for event in events | sort(attribute="from") %}
 
-          {# Check consistency of start and end times #}
-          {% if i != 0 and previous_end != event.from %}
-            {{ throw(message="Inconsistent start time for " ~ "'" ~ event.title ~ "'" ) }}
-          {% endif %}
-          {% set_global previous_end = event.to %}
-
           {# Transform from and to as timestamps #}
           {% set from = macros::timestamp(day=event.day, hhmm=event.from) %}
           {% set to = macros::timestamp(day=event.day, hhmm=event.to) %}
+
+          {# Check consistency of start and end times #}
+          {% set from_unix = from | date(format="%s") | int %}
+          {% if previous_end > from_unix %}
+            {{ throw(message="Inconsistent start time for " ~ "'" ~ event.title ~ "'" ) }}
+          {% endif %}
+          {% set_global previous_end = to | date(format="%s") | int %}
+
 
           <li>
             <span class="timeline-date">


### PR DESCRIPTION
Fix the logic for checking inconsistencies on time schedule in the
program. Compare numerical values by converting timestamps to UNIX
timestamps.
